### PR TITLE
Removing libevent package (bugfix)

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -4,11 +4,6 @@ class prosody::package {
     fail("Currently the prosody module only supports Ubuntu\nSee <https://github.com/rtyler/puppet-prosody> for more")
   }
 
-  # for libevent support
-  package { 'lua-event':
-    ensure => present,
-  } ->
-
   package { 'prosody' :
     ensure  => present,
     # Package[openssl] will be required to generate certificates and such


### PR DESCRIPTION
Prosody automatically includes the necessary libevent package when it is
installed.

This fixes the bug of including libevent, which at least exists on Ubuntu 12.04. Regardless if newer versions have the libevent package, as long as the prosody package automatically installs it, we should not require it here.
