### PR TITLE
Using ensure_packages instead of ensure_resource

### DIFF
--- a/manifests/community_modules.pp
+++ b/manifests/community_modules.pp
@@ -3,8 +3,7 @@ class prosody::community_modules (
   $modules = [],
 ) {
 
-  ensure_resource('package', 'mercurial')
-
+  ensure_packages(['mercurial'])
   vcsrepo { $path:
     ensure   => present,
     provider => hg,


### PR DESCRIPTION
The ensure_packages function is slightly more relevant than ensure_resource here. (Used only on mercurial package in community thing).
