### PR TITLE
Removing openssl package

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -11,14 +11,5 @@ class prosody::package {
 
   package { 'prosody' :
     ensure  => present,
-    # Package[openssl] will be required to generate certificates and such
-    require => Package[openssl];
-  }
-
-  if (!defined(Package[openssl])) {
-    package {
-      'openssl' :
-        ensure => present;
-    }
   }
 }


### PR DESCRIPTION
Again, Prosody automatically includes openssl when installed.

So we shouldn't require it, apt does it for us. Package requirements in Puppet are really iffy, especially for packages that are shared dependencies (such as this). So long as apt pulls it in for us, let's not step on other modules.

If we do _have_ to have it, use ensure_packages([package]).
