### PR TITLE
Allow setting the user to run prosody as.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,7 @@
 class prosody (
   $admins = [],
+  $user = 'root',
+  $group = 'root',
   $interfaces = ['0.0.0.0', '::'],
   $allow_registration = false,
   $ssl_protocol = 'tlsv1',

--- a/templates/prosody.cfg.erb
+++ b/templates/prosody.cfg.erb
@@ -25,6 +25,10 @@ admins = {
 <% end -%>
 }
 
+-- User to run prosody as
+prosody_user = "<%= scope.lookupvar('prosody::user') %>"
+prosody_group = "<%= scope.lookupvar('prosody::group') %>"
+
 -- Which interfaces (addresses) to listen on
 interfaces = {
 <% scope.lookupvar('prosody::interfaces').each do |interface| -%>


### PR DESCRIPTION
While it can already be set via 'custom_options', it's important
enough to encourage dropping privileges.

Case in point, prosody runs as unprivileged _prosody:_prosody on OpenBSD.
