### PR TITLE
Prosody has an rc.d script on OpenBSD, so it can be enabled like any other service.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ class prosody::config {
 
   file { '/etc/prosody/prosody.cfg.lua':
     content => template('prosody/prosody.cfg.erb'),
+    require => Class[prosody::package],
     notify  => Service['prosody'],
   }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,5 +1,4 @@
 class prosody::package {
-
   package { 'prosody' :
     ensure  => present,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,19 @@
 class prosody::service {
-  service {
-    'prosody' :
-      ensure    => running,
-      hasstatus => false,
-      restart   => '/usr/bin/prosodyctl reload',
-      require   => Class[prosody::package],
+  case $::osfamily {
+    'OpenBSD': {
+      service { 'prosody':
+        ensure  => running,
+        enable  => true,
+        require => Class[prosody::config],
+      }
+    }
+    default: {
+      service { 'prosody' :
+        ensure    => running,
+        hasstatus => false,
+        restart   => '/usr/bin/prosodyctl reload',
+        require   => Class[prosody::config],
+      }
+    }
   }
 }


### PR DESCRIPTION
While here, adjust dependencies a bit, by ensuring the package (and thus `/etc/prosody`) are present before installing the config file, and by letting the service depend on the config file, not the package.
