### PR TITLE
fix unsafe default & improve doco

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,31 @@ module to use.
 
 ## Using
 
-**Note:** This module has currently only been tested on Ubuntu and OpenBSD.
+**Note:** This module has currently been tested on CentOS 7, Ubuntu and OpenBSD.
 
 ```puppet
-node default {
-  include prosody
+node myserver {
+
+  class { 'prosody':
+    user              => 'prosody',
+    group             => 'prosody',
+    community_modules => ['mod_auth_ldap'],
+    authentication    => 'ldap',
+    custom_options    => {
+                            'ldap_base'     => 'OU="accounts",DC="mydomain",DC="com"',
+                            'ldap_server'   => 'ldapserver1:636 ldapserver2:636',
+                            'ldap_rootdn'   => 'DN="prosody",OU="accounts",DC="mydomain",DC="com"',
+                            'ldap_password' => hiera(prosody-ldap-password),
+                            'ldap_scope'    => 'subtree',
+                            'ldap_tls'      => 'true',
+                          },
+  }
 
   prosody::virtualhost {
     'mydomain.com' :
-      ensure => present;
+      ensure   => present,
+      ssl_key  => '/etc/ssl/key/mydomain.com.key',
+      ssl_cert => '/etc/ssl/crt/mydomain.com.crt',
   }
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 class prosody (
   $admins = [],
   $pidfile = '/var/run/prosody/prosody.pid',
-  $user = 'root',
-  $group = 'root',
+  $user = 'prosody',
+  $group = 'prosody',
   $info_log = '/var/log/prosody/prosody.log',
   $error_log = '/var/log/prosody/prosody.err',
   $log_sinks = ['syslog'],


### PR DESCRIPTION
1. Don't run as root by default, see: prosody.im/doc/root, newer versions even refuse to run as root and will fail to start.

2. Improve documentation to help with #14