### PR TITLE
Allow configuration of disabled modules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class prosody (
   ],
   $modules                = [],
   $community_modules      = [],
+  $disabled_modules       = [],
   $components             = {},
   $virtualhosts           = {},
   $virtualhost_defaults   = {},

--- a/templates/prosody.cfg.erb
+++ b/templates/prosody.cfg.erb
@@ -70,7 +70,11 @@ plugin_paths = {
 
 -- These modules are auto-loaded, but should you want
 -- to disable them then uncomment them here:
-modules_disabled = {};
+modules_disabled = {
+<% scope.lookupvar('prosody::disabled_modules').each do |mod| -%>
+    "<%= mod %>";
+<% end -%>
+};
 
 -- Disable account creation by default, for security
 -- For more information see http://prosody.im/doc/creating_accounts


### PR DESCRIPTION
Option for disabling modules in puppet config. By default, no modules are disabled.
