### PR TITLE
Parse custom_options of profile::virtualhost

### DIFF
--- a/templates/virtualhost.cfg.erb
+++ b/templates/virtualhost.cfg.erb
@@ -15,6 +15,20 @@ VirtualHost "<%= @name %>"
     certificate = "<%= @prosody_ssl_cert %>";
   }
 <% end -%>
+
+<%- if @custom_options != {} -%>
+------ Custom config options ------
+<%- @custom_options.sort.each do |option, value| -%>
+  <%- if value.is_a?(String) then -%>
+<%= option %> = "<%= value %>"
+  <%- elsif value.is_a?(Array) then -%>
+<%= option %> = { <%= value.collect { |x| "\"#{x}\"" }.join("; ") %> }
+  <%- else -%>
+<%= option %> = <%= value %>
+  <%- end -%>
+<%- end -%>
+<%- end -%>
+
 <%- if @components != {} -%>
 ------ Components ------
 -- You can specify components to add hosts that provide special services,
@@ -33,15 +47,3 @@ Component "<%= name %>" <% if component.include?('type') then %>"<%= component['
   <%- end -%>
 <% end -%>
 <% end -%>
-<%- if @custom_options != {} -%>
------- Custom config options ------
-<%- @custom_options.sort.each do |option, value| -%>
-  <%- if value.is_a?(String) then -%>
-<%= option %> = "<%= value %>"
-  <%- elsif value.is_a?(Array) then -%>
-<%= option %> = { <%= value.collect { |x| "\"#{x}\"" }.join("; ") %> }
-  <%- else -%>
-<%= option %> = <%= value %>
-  <%- end -%>
-<%- end -%>
-<%- end -%>

--- a/templates/virtualhost.cfg.erb
+++ b/templates/virtualhost.cfg.erb
@@ -36,6 +36,12 @@ Component "<%= name %>" <% if component.include?('type') then %>"<%= component['
 <%- if @custom_options != {} -%>
 ------ Custom config options ------
 <%- @custom_options.sort.each do |option, value| -%>
+  <%- if value.is_a?(String) then -%>
+<%= option %> = "<%= value %>"
+  <%- elsif value.is_a?(Array) then -%>
+<%= option %> = { <%= value.collect { |x| "\"#{x}\"" }.join("; ") %> }
+  <%- else -%>
 <%= option %> = <%= value %>
+  <%- end -%>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
I'm having problems with some options not enclosed by `"` in virtualhost config files (for example, with `authentication` option).

So I have modified the template to parse `custom_options`:
* if the value is a string, put it surrounded by `""`
* if the value is an array, joins all values enclosed by `{ }`

I have also put `custom_config` before any `component` config.