### PR TITLE
Allow to pass a hash to custom_options

### DIFF
--- a/templates/virtualhost.cfg.erb
+++ b/templates/virtualhost.cfg.erb
@@ -23,6 +23,12 @@ VirtualHost "<%= @name %>"
 <%= option %> = "<%= value %>"
   <%- elsif value.is_a?(Array) then -%>
 <%= option %> = { <%= value.collect { |x| "\"#{x}\"" }.join("; ") %> }
+  <%- elsif value.is_a?(Hash) then -%>
+<%= option %> = {
+    <%- value.each do |key, value| -%>
+  <%= key %> = "<%= value %>";
+    <%- end -%>
+}
   <%- else -%>
 <%= option %> = <%= value %>
   <%- end -%>


### PR DESCRIPTION
For instance I would like to generate:

```lua
------ Custom config options ------
http_paths = {
  bosh = "/http-bind"
}
```