### PR TITLE
Use Puppet-4-Datatypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 script: "bundle exec rake validate lint spec"
-rvm:
-  - 2.1.9
-env:
-  - PUPPET_VERSION=3.8.7
-  - PUPPET_VERSION=4.10.6
+matrix:
+  include:
+    - env: PUPPET_VERSION=4.10.12
+      rvm: 2.1.9
+    - env: PUPPET_VERSION=5.5.10
+      rvm: 2.4.1
+    - env: PUPPET_VERSION=6.2.0
+      rvm: 2.5.1

--- a/manifests/community_modules.pp
+++ b/manifests/community_modules.pp
@@ -1,18 +1,21 @@
 # == Class: prosody::community_modules
 class prosody::community_modules(
-  $ensure   = 'present',
-  $path     = '/var/lib/prosody/modules',
-  $type     = 'hg',
-  $source   = 'https://hg.prosody.im/prosody-modules/',
-  $revision = undef,
+  Enum[present, latest] $ensure   = present,
+  Stdlib::Absolutepath  $path     = '/var/lib/prosody/modules',
+  Enum['hg', 'git']     $type     = 'hg',
+  String                $source   = 'https://hg.prosody.im/prosody-modules/',
+  Optional[String]      $revision = undef,
 ) {
-  ensure_packages(['mercurial'])
-
-  vcsrepo { $path:
+  case $type {
+    'hg':    { $_packages = ['mercurial'] }
+    'git':   { $_packages = ['git'] }
+    default: { $_packages = [] }
+  }
+  ensure_packages($_packages)
+  -> vcsrepo { $path:
     ensure   => $ensure,
     provider => $type,
     source   => $source,
     revision => $revision,
-    require  => Package['mercurial'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,95 +1,73 @@
 # == Class: prosody
 class prosody(
-  $package_name           = 'prosody',
-  $package_ensure         = 'present',
-  $admins                 = [],
-  $pidfile                = '/var/run/prosody/prosody.pid',
-  $user                   = 'prosody',
-  $group                  = 'prosody',
-  $log_level              = 'info',
-  $info_log               = '/var/log/prosody/prosody.log',
-  $error_log              = '/var/log/prosody/prosody.err',
-  $log_sinks              = ['syslog'],
-  $use_libevent           = true,
-  $interfaces             = ['0.0.0.0', '::'],
-  $daemonize              = true,
-  $allow_registration     = false,
-  $ssl_custom_config      = true,
-  $ssl_key                = undef,
-  $ssl_cert               = undef,
-  $ssl_protocol           = undef,
-  $ssl_options            = [
+  String                         $package_name           = 'prosody',
+  Variant[
+    Enum[present, latest],
+    String
+  ]                              $package_ensure         = present,
+  Array[String]                  $admins                 = [],
+  Stdlib::Absolutepath           $pidfile                = '/var/run/prosody/prosody.pid',
+  String                         $user                   = 'prosody',
+  String                         $group                  = 'prosody',
+  Enum[
+    'debug',
+    'info',
+    'warn',
+    'error' # lint:ignore:trailing_comma # (Bug in puppet-lint)
+  ]                              $log_level              = 'info',
+  Stdlib::Absolutepath           $info_log               = '/var/log/prosody/prosody.log',
+  Stdlib::Absolutepath           $error_log              = '/var/log/prosody/prosody.err',
+  Array[String]                  $log_sinks              = ['syslog'],
+  Boolean                        $use_libevent           = true,
+  Array[Stdlib::IP::Address]     $interfaces             = ['0.0.0.0', '::'],
+  Boolean                        $daemonize              = true,
+  Boolean                        $allow_registration     = false,
+  Boolean                        $ssl_custom_config      = true,
+  Optional[Stdlib::Absolutepath] $ssl_key                = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cert               = undef,
+  Optional[String]               $ssl_protocol           = undef,
+  Array[String]                  $ssl_options            = [
     'no_sslv2', 'no_sslv3', 'no_ticket', 'no_compression',
     'cipher_server_preference', 'single_dh_use', 'single_ecdh_use',
   ],
-  $ssl_ciphers            = 'DH+AES:ECDH+AES:+ECDH+SHA:AES:!PSK:!SRP:!DSS:!ADH:!AECDH',
-  $ssl_dhparam            = '', # lint:ignore:empty_string_assignment
-  $ssl_curve              = 'secp521r1',
-  $c2s_require_encryption = true,
-  $s2s_require_encryption = true,
-  $s2s_secure_auth        = true,
-  $s2s_insecure_domains   = [],
-  $s2s_secure_domains     = [],
-  $authentication         = 'internal_plain',
-  $storage                = 'internal',
-  $sql                    = undef,
-  $modules_base           = [
+  String                         $ssl_ciphers            = 'DH+AES:ECDH+AES:+ECDH+SHA:AES:!PSK:!SRP:!DSS:!ADH:!AECDH',
+  String                         $ssl_dhparam            = '', # lint:ignore:empty_string_assignment
+  String                         $ssl_curve              = 'secp521r1',
+  Boolean                        $c2s_require_encryption = true,
+  Boolean                        $s2s_require_encryption = true,
+  Boolean                        $s2s_secure_auth        = true,
+  Array[Stdlib::Fqdn]            $s2s_insecure_domains   = [],
+  Array[Stdlib::Fqdn]            $s2s_secure_domains     = [],
+  Enum[
+    'internal_plain',
+    'internal_hashed',
+    'cyrus',
+    'anonymous' # lint:ignore:trailing_comma # (Bug in puppet-lint)
+  ]                              $authentication         = 'internal_plain',
+  Variant[
+    Hash,
+    Enum[
+      'internal',
+      'sql',
+      'memory',
+      'null',
+      'none' # lint:ignore:trailing_comma # (Bug in puppet-lint)
+    ]
+  ]                              $storage                = 'internal',
+  Optional[Hash]                 $sql                    = undef,
+  Array[String]                  $modules_base           = [
     'roster', 'saslauth', 'tls', 'dialback', 'disco',
     'posix', 'private', 'vcard', 'version', 'uptime',
     'time', 'ping', 'pep', 'admin_adhoc',
   ],
-  $modules                = [],
-  $modules_disabled       = [],
-  $community_modules      = [],
-  $components             = {},
-  $virtualhosts           = {},
-  $virtualhost_defaults   = {},
-  $custom_options         = {},
+  Array[String]                  $modules                = [],
+  Array[String]                  $modules_disabled       = [],
+  Array[String]                  $community_modules      = [],
+  Hash                           $components             = {},
+  Hash                           $virtualhosts           = {},
+  Hash                           $virtualhost_defaults   = {},
+  Hash                           $custom_options         = {},
 ) {
-  validate_bool($use_libevent)
-  validate_bool($daemonize)
-  validate_bool($allow_registration)
-  validate_bool($c2s_require_encryption)
-  validate_bool($s2s_require_encryption)
-  validate_bool($s2s_secure_auth)
-
-  validate_string($pidfile)
-  validate_string($user)
-  validate_string($group)
-  validate_string($info_log)
-  validate_string($error_log)
-  validate_string($ssl_protocol)
-  validate_string($ssl_ciphers)
-  if $ssl_dhparam != undef {
-    validate_string($ssl_dhparam)
-  }
-  if $ssl_key != undef {
-    validate_string($ssl_key)
-  }
-  if $ssl_cert != undef {
-    validate_string($ssl_cert)
-  }
-  validate_string($ssl_curve)
-  validate_string($authentication)
-  validate_string($package_name)
-  validate_string($package_ensure)
-
-  validate_array($admins)
-  validate_array($log_sinks)
-  validate_array($interfaces)
-  validate_array($ssl_options)
-  validate_array($s2s_insecure_domains)
-  validate_array($s2s_secure_domains)
-  validate_array($modules_base)
-  validate_array($modules)
-  validate_array($modules_disabled)
-  validate_array($community_modules)
-
-  validate_hash($components)
-  validate_hash($virtualhosts)
-  validate_hash($virtualhost_defaults)
-  validate_hash($custom_options)
-
   if ($community_modules != []) {
     class { '::prosody::community_modules':
       require => Class['::prosody::package'],

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,7 +1,10 @@
 # == Type: prosody::user
 define prosody::user(
-  $pass,
-  $host = 'localhost',
+  String                    $pass,
+  Variant[
+    Pattern[/^localhost$/],
+    Stdlib::Host
+  ]                         $host = 'localhost',
 ) {
   $dir = regsubst($host, '\.', '%2e', 'G')
 

--- a/manifests/virtualhost.pp
+++ b/manifests/virtualhost.pp
@@ -1,12 +1,12 @@
 # == Type: prosody::virtualhost
 define prosody::virtualhost(
-  $custom_options = {},
-  $ensure         = present,
-  $ssl_key        = undef,
-  $ssl_cert       = undef,
-  $user           = undef,
-  $group          = undef,
-  $components     = {},
+  Hash                           $custom_options = {},
+  Enum[present, absent]          $ensure         = present,
+  Optional[Stdlib::Absolutepath] $ssl_key        = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cert       = undef,
+  Optional[String]               $user           = undef,
+  Optional[String]               $group          = undef,
+  Hash                           $components     = {},
 ) {
   # Check if SSL set correctly
   if (($ssl_key != undef) and ($ssl_cert == undef)) {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0"
     },
     {
       "name": "puppetlabs/vcsrepo",
@@ -20,7 +20,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 6.0.0"
+      "version_requirement": ">= 4.10.12 < 7"
     }
   ]
 }


### PR DESCRIPTION
- use Puppet-4-Datatypes
- use Datatypes from Puppet-Stdlib >= 4.25

I will define separate Types for the long Enum-stuff in a following
Pull-Request.