### PR TITLE
Drop support for EOL Ubuntu 20.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04",
         "24.04"
       ]


### PR DESCRIPTION
- **Add support for Ubuntu 22.04 and 24.04**
- **Drop support for EOL Ubuntu 20.04**
